### PR TITLE
Fix the format of 'data'

### DIFF
--- a/lib/degiro/connection.rb
+++ b/lib/degiro/connection.rb
@@ -35,8 +35,7 @@ module DeGiro
 
       @session_id = response.headers['set-cookie'][/JSESSIONID=(.*?);/m, 1]
       raise MissingSessionIdError, 'Could not find valid session id' if @session_id == '' || @session_id.nil?
-
-      @urls_map = UrlsMap.new(JSON.parse(@conn.get('/login/secure/config').body))
+      @urls_map = UrlsMap.new(JSON.parse(@conn.get('/login/secure/config').body)["data"])
       @user_data = UserData.new(JSON.parse(@conn.get("#{@urls_map['pa_url']}/client?sessionId=#{@session_id}").body)['data'])
     end
   end


### PR DESCRIPTION
Degiro API might have changed something as data now is nested and the current code breaks with errors:

```
irb(main):002:0> client = DeGiro::Client.new(login: 'user-name', password: 'password')
Traceback (most recent call last):
       13: from /Users/sfistak/.gem/ruby/3.0.0/bin/irb:23:in `<main>'
       12: from /Users/sfistak/.gem/ruby/3.0.0/bin/irb:23:in `load'
       11: from /Users/sfistak/.rubies/3.0.0/lib/ruby/gems/3.0.0/gems/irb-1.3.0/exe/irb:11:in `<top (required)>'
       10: from (irb):2:in `<main>'
        9: from (irb):2:in `new'
        8: from /Users/sfistak/Code/ruby-or-rails/degiro/lib/degiro/client.rb:28:in `initialize'
        7: from /Users/sfistak/Code/ruby-or-rails/degiro/lib/degiro/client.rb:28:in `new'
        6: from /Users/sfistak/Code/ruby-or-rails/degiro/lib/degiro/connection.rb:38:in `initialize'
        5: from /Users/sfistak/Code/ruby-or-rails/degiro/lib/degiro/connection.rb:38:in `new'
        4: from /Users/sfistak/Code/ruby-or-rails/degiro/lib/degiro/urls_map.rb:15:in `initialize'
        3: from /Users/sfistak/Code/ruby-or-rails/degiro/lib/degiro/urls_map.rb:15:in `each_with_object'
        2: from /Users/sfistak/Code/ruby-or-rails/degiro/lib/degiro/urls_map.rb:15:in `each'
        1: from /Users/sfistak/Code/ruby-or-rails/degiro/lib/degiro/urls_map.rb:16:in `block in initialize'
DeGiro::MissingUrlError (Could not find url 'paUrl')
irb(main):003:0>
```

After applying the code change and getting the information from ["data"] the code works perfectly

irb(main):003:0> client = DeGiro::Client.new(login: 'user-name', password: 'password')
=> #<DeGiro::Client:0x0000000115b44ba8 @create_order=#<DeGiro::CreateOrder:0x0000000115938fa8 @connection=#<DeGiro...
irb(main):004:0>
